### PR TITLE
Add is_male filter and randomizer

### DIFF
--- a/server/queries.js
+++ b/server/queries.js
@@ -7,8 +7,14 @@ const pool = new Pool({
   port: 5432,
 })
 
-const getNames = (request, response) => {
-  pool.query('SELECT * FROM pet_names ORDER BY id ASC', (error, results) => {
+const getNames = async (request, response) => {
+  const isMale = request.query.is_male || null;
+  const whereClause = isMale != null ? `WHERE is_male = ${isMale}` : '';
+
+  const { rows } = await pool.query(`SELECT COUNT(*) FROM pet_names ${whereClause}`);
+  const recordCount = rows[0].count;
+
+  pool.query(`SELECT * FROM pet_names ${whereClause} OFFSET floor(random() * ${recordCount}) LIMIT 1`, (error, results) => {
     if (error) {
       throw error
     }


### PR DESCRIPTION
1. Add randomizer to index query. Limit to one result. Note: this is still an array, even though there's only one result. This makes it easy to scale in case we want say 5 or more random results later.
2. Add `is_male` filter to index query. `true` is male, `false` is female.

Endpoint is now consumed like so:

- `GET /names` Any random name from the database, regardless of male/female.
- `GET /names?is_male=true` Random male name.
- `GET /names?is_male=false` Random female name.